### PR TITLE
fix: update RADIX

### DIFF
--- a/FF-1/common-utils/CommonUtils.js
+++ b/FF-1/common-utils/CommonUtils.js
@@ -396,6 +396,7 @@ class CommonUtils {
         if(!sanitizedInput) {
             throw ("sanitizedInput cannot be empty or a null value");
         }
+        RADIX = 10;
         updatedCharMap = charMap.convertToMap(this.getNumericCharacters());
         let code, i, len;
         for(i=0, len=sanitizedInput.length; i < len; i++) {


### PR DESCRIPTION
I encountered a bug where calling encrypt first with alphanumeric input cause subsequent encrypt with numeric only inputs to fail.

```
const encryptDecryptUtil = new cryptoUtil(key, tweak);

console.log(encryptDecryptUtil.encrypt("abc"));
// Fsl

console.log(encryptDecryptUtil.encrypt("1234567890"));
// 0285
```

The issue is the RADIX is set to 62 on the first call of encrypt and is not changed to 10 during the second call. 